### PR TITLE
mistral-common 1.9.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,30 +1,40 @@
 {% set name = "mistral-common" %}
-{% set version = "1.8.3" %}
+{% set version = "1.9.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/mistral_common-{{ version }}.tar.gz
-  sha256: 0d1979d82227b625f6d71b3c828176f059da8d0f5a3307cdf53b48409a3970a4
+  - url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/mistral_common-{{ version }}.tar.gz
+    sha256: 550583d70a395c3586cfb748ffab53bd1d7c3409507f0efc0118bff30ffb26e9
+  - url: https://raw.githubusercontent.com/mistralai/mistral-common/v{{ version }}/LICENCE
+    sha256: 5ed6f79e77734b5a60740dd821af5ecac9a6f33709c860eea4e20fcb6cca7fcc
+    fn: LICENSE
+
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: true  # [py<39 or py>313]
+  script:
+    - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  # pyproject.toml currently limits the python version to less than 3.14
+  skip: true  # [py<310 or py>313]
 
 requirements:
   host:
     - pip
     - python
     - wheel
-    - setuptools >=42
+    # setuptools must be at least this version for compatibility with PEP639. The pyproject.toml
+    # for mistral-common looks to be defined with this PEP in mind, so setuptools needs
+    # to support it as well. 
+    # https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files
+    - setuptools >=77.0.3
   run:
     - python
     - pydantic >=2.7,<3.0
     - jsonschema >=4.21.1
-    - sentencepiece >=0.2.0
+    
     - typing-extensions >=4.11.0
     - tiktoken >=0.7.0
     - pillow >=10.3.0
@@ -34,10 +44,11 @@ requirements:
     # pydantic-extra-types[pycountry]
     - pycountry >=23
   run_constrained:
+    - sentencepiece >=0.2.0
     - opencv >=4.0.0
     - opencv-python-headless >=4.0.0
     - soundfile >=0.12.1
-    - soxr >=0.5.0
+    - soxr-python >=0.5.0
     - huggingface-hub >=0.32.4
     - fastapi >=0.115.12
     - pydantic-settings >=2.9.1
@@ -61,7 +72,7 @@ about:
   description: |
     Set of tools to help you work with Mistral models.
   license: Apache-2.0
-  license_file: LICENCE
+  license_file: LICENSE
   license_family: Apache
   dev_url: https://github.com/mistralai/mistral-common
   doc_url: https://github.com/mistralai/mistral-common


### PR DESCRIPTION
mistral-common 1.9.1

**Destination channel:** defaults

### Links

- [PKG-12731](https://anaconda.atlassian.net/browse/PKG-12731) 
- Upstream repo: https://github.com/mistralai/mistral-common
- Upstream release notes: https://github.com/mistralai/mistral-common/releases
- conda-forge repo: https://github.com/conda-forge/mistral-common-feedstock
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- Updating to new version
- changing the `soxr` dependency to `soxr-python`. The pyproject.toml lists the python package `soxr`, but the conda package of the same name is a compiled library. Conda-forge has a `soxr-python` package that appears to be the correct package.


[PKG-12731]: https://anaconda.atlassian.net/browse/PKG-12731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ